### PR TITLE
ci: add workflow for duplicating issues

### DIFF
--- a/.github/workflows/issue.yaml
+++ b/.github/workflows/issue.yaml
@@ -59,8 +59,10 @@ jobs:
 
       - name: Create Project Card
         id: create_project_card
+        env:
+          PROJECT_ID: PVT_kwDOCVI7fM4AjJOl
         run: |
           curl --request POST \
             --url https://api.github.com/graphql \
             --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            --data '{"query":"mutation {addProjectV2ItemById(input: {projectId: \"${{ secrets.PROJECT_ID }}\" contentId: \"${{ steps.get_issue_id.outputs.issue_id }}\"}) {item {id}}}"}' 
+            --data '{"query":"mutation {addProjectV2ItemById(input: {projectId: \"${{ env.PROJECT_ID }}\" contentId: \"${{ steps.get_issue_id.outputs.issue_id }}\"}) {item {id}}}"}' 

--- a/.github/workflows/issue.yaml
+++ b/.github/workflows/issue.yaml
@@ -11,13 +11,30 @@ jobs:
   create-issue:
     if: contains(github.event.issue.labels.*.name, 'validatorctl')
     runs-on: [self-hosted, Linux, X64, validator]
+
     steps:
       - name: Filter Labels
-        id: filter_labels 
-        run: |
-          LABELS=$(echo '${{ toJson(github.event.issue.labels) }}' | jq -r '[.[] | select(.name != "validatorctl") | .name] | join(",")')
-          echo "::set-output name=labels::$LABELS"
+        uses: actions/github-script@v7
+        id: filter_labels
+        env:
+          LABELS_JSON: ${{ toJson(github.event.issue.labels) }}
+          LABEL_NAME: validatorctl
+        with: 
+          script: |
+            const fs = require('fs');
+
+            const labels = JSON.parse(process.env.LABELS_JSON);
+            const labelToExclude = process.env.LABEL_NAME;
+
+            const filteredLabels = labels
+              .filter(label => label.name !== labelToExclude)
+              .map(label => label.name);
+
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `labels=${filteredLabels.join(',')}\n`);
+          result-encoding: string
+
       - name: Create Issue
+        id: create_issue
         uses: dacbd/create-issue-action@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -25,5 +42,25 @@ jobs:
           body: ${{ github.event.issue.body }}
           owner: validator-labs
           repo: validatorctl
-          assignees: ${{ github.event.issue.assignees.*.login }}
+          assignees: ${{ join(github.event.issue.assignees.*.login, ',') }}
           labels: ${{ steps.filter_labels.outputs.labels }}
+
+      - name: Get Issue ID
+        id: get_issue_id
+        uses: actions/github-script@v7
+        env:
+          ISSUE_JSON: ${{ steps.create_issue.outputs.json }}
+        with:
+          script: |
+            const fs = require('fs');
+            const issueJson = JSON.parse(process.env.ISSUE_JSON);
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `issue_id=${issueJson.node_id}\n`);
+          result-encoding: string
+
+      - name: Create Project Card
+        id: create_project_card
+        run: |
+          curl --request POST \
+            --url https://api.github.com/graphql \
+            --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            --data '{"query":"mutation {addProjectV2ItemById(input: {projectId: \"${{ secrets.PROJECT_ID }}\" contentId: \"${{ steps.get_issue_id.outputs.issue_id }}\"}) {item {id}}}"}' 

--- a/.github/workflows/issue.yaml
+++ b/.github/workflows/issue.yaml
@@ -1,0 +1,29 @@
+name: Create Issue
+
+on: 
+  workflow_call:
+
+concurrency: 
+  group: create-issue-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  create-issue:
+    if: contains(github.event.issue.labels.*.name, 'validatorctl')
+    runs-on: [self-hosted, Linux, X64, validator]
+    steps:
+      - name: Filter Labels
+        id: filter_labels 
+        run: |
+          LABELS=$(echo '${{ toJson(github.event.issue.labels) }}' | jq -r '[.[] | select(.name != "validatorctl") | .name] | join(",")')
+          echo "::set-output name=labels::$LABELS"
+      - name: Create Issue
+        uses: dacbd/create-issue-action@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: ${{ github.event.issue.title }}
+          body: ${{ github.event.issue.body }}
+          owner: validator-labs
+          repo: validatorctl
+          assignees: ${{ github.event.issue.assignees.*.login }}
+          labels: ${{ steps.filter_labels.outputs.labels }}


### PR DESCRIPTION
## Issue

## Description
Adding a workflow to allow automatic creation of issues in validatorctl, based on an issue in a plugin repo.

The workflow is triggered by opening a new issue in any plugin repo. If the `validatorctl` label is present, it will create an exact copy of the issue in the github.com/validator-labs/validatorctl repo, only without the `validatorctl` label.