### PR TITLE
ci: add docs.crd.dev index update step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,8 +57,8 @@ jobs:
       - name: Trigger docs.crd.dev index
         if: needs.release-please.outputs.releases_created == 'true'
         run: |
-          curl -v https://doc.crds.dev/github.com/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}@${{ github.event.outputs.tag_name }}
-          echo "Triggered docs.crd.dev to index ${{ github.event.repository.name }}@${{ github.event.outputs.tag_name }}"
+          curl -v https://doc.crds.dev/github.com/validator-labs/${{ github.event.repository.name }}@${{ needs.release-please.outputs.tag_name }}
+          echo "Triggered docs.crd.dev to index ${{ github.event.repository.name }}@${{ needs.release-please.outputs.tag_name }}"
   build-container:
     if: needs.release-please.outputs.releases_created == 'true'
     needs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,8 +55,9 @@ jobs:
           commit_username: validator-labs-bot
           commit_email: bot@noreply.validator-labs.io
       - name: Trigger docs.crd.dev index
+        if: ${{ needs.release-please.outputs.tag_name }}
         run: |
-          curl -v https://doc.crds.dev/github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}@${{ github.event.inputs.tag }}
+          curl -v https://doc.crds.dev/github.com/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}@${{ github.event.inputs.tag }}
           echo "Triggered docs.crd.dev to index ${{ github.event.repository.name }}@${{ github.event.inputs.tag }}"
   build-container:
     if: needs.release-please.outputs.releases_created == 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,10 +55,10 @@ jobs:
           commit_username: validator-labs-bot
           commit_email: bot@noreply.validator-labs.io
       - name: Trigger docs.crd.dev index
-        if: ${{ needs.release-please.outputs.tag_name }}
+        if: needs.release-please.outputs.releases_created == 'true'
         run: |
-          curl -v https://doc.crds.dev/github.com/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}@${{ github.event.inputs.tag }}
-          echo "Triggered docs.crd.dev to index ${{ github.event.repository.name }}@${{ github.event.inputs.tag }}"
+          curl -v https://doc.crds.dev/github.com/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}@${{ github.event.outputs.tag_name }}
+          echo "Triggered docs.crd.dev to index ${{ github.event.repository.name }}@${{ github.event.outputs.tag_name }}"
   build-container:
     if: needs.release-please.outputs.releases_created == 'true'
     needs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,10 @@ jobs:
           branch: ${{ env.GITHUB_PAGES_BRANCH }}
           commit_username: validator-labs-bot
           commit_email: bot@noreply.validator-labs.io
-          
+      - name: Trigger docs.crd.dev index
+        run: |
+          curl -v https://doc.crds.dev/github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}@${{ github.event.inputs.tag }}
+          echo "Triggered docs.crd.dev to index ${{ github.event.repository.name }}@${{ github.event.inputs.tag }}"
   build-container:
     if: needs.release-please.outputs.releases_created == 'true'
     needs:


### PR DESCRIPTION
## Description
Adds  step to the release workflow that triggers the doc.crds.dev index. Follows the existing pattern using `github.event` for repo name and `needs.release-please.outputs` for the new tag.

Cannot test this until we need to do another Helm chart release in either the core repo or a plugin repo.
