### PR TITLE
chore: Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:base",
     "helpers:pinGitHubActionDigests",
-    ":gitSignOff"
+    ":gitSignOff",
+    "group:allNonMajor"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Adds `group:allNonMajor` for fewer dep update PRs going forward.