### PR TITLE
feat: switch to building image for each helm test run

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,7 +62,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64, validator]
     if: "!(contains(github.head_ref, 'release-please') || contains(github.ref, 'release-please'))"
     env:
-      IMAGE_TAG: ${{ github.run_id }}
+      IMAGE_TAG: ${{ github.event.repository.default_branch }}
       IMAGE: quay.io/validator-labs/${{ github.event.repository.name }}
 
     steps:
@@ -127,7 +127,9 @@ jobs:
             ${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
           builder: ${{ steps.buildx.outputs.name }}
           push: false
-          # load: true
+          cache-from: type=gha,scope=${{ github.ref_name }}-${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
+          cache-to: type=gha,scope=${{ github.ref_name }}-${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
+          load: true
 
       - name: Load Docker Image into kind Cluster
         run: kind load docker-image ${{ env.IMAGE }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,6 +61,10 @@ jobs:
     name: Run Helm Chart Tests
     runs-on: [self-hosted, Linux, X64, validator]
     if: "!(contains(github.head_ref, 'release-please') || contains(github.ref, 'release-please'))"
+    env:
+      IMAGE_TAG: ${{ github.run_id }}
+      IMAGE: quay.io/validator-labs/${{ github.event.repository.name }}
+
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -108,6 +112,28 @@ jobs:
         with:
           cluster_name: ct-${{ steps.short-sha.outputs.sha }}
 
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          target: production
+          tags: |
+            ${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
+          builder: ${{ steps.buildx.outputs.name }}
+          push: false
+          cache-from: type=gha,scope=${{ github.ref_name }}-${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
+          cache-to: type=gha,scope=${{ github.ref_name }}-${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
+          load: true
+
+      - name: Load Docker Image into kind Cluster
+        run: kind load docker-image ${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
+
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --chart-dirs chart  --target-branch ${{ github.event.repository.default_branch }}
+        run: ct install --chart-dirs chart --helm-extra-set-args "--set=controllerManager.manager.image.tag=${{ env.IMAGE_TAG }}" --target-branch ${{ github.event.repository.default_branch }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,7 +62,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64, validator]
     if: "!(contains(github.head_ref, 'release-please') || contains(github.ref, 'release-please'))"
     env:
-      IMAGE_TAG: ${{ github.event.repository.default_branch }}
+      IMAGE_TAG: latest-dev
       IMAGE: quay.io/validator-labs/${{ github.event.repository.name }}
 
     steps:
@@ -132,7 +132,7 @@ jobs:
           load: true
 
       - name: Load Docker Image into kind Cluster
-        run: kind load docker-image ${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
+        run: kind load docker-image ${{ env.IMAGE }}:${{ env.IMAGE_TAG }} --name ct-${{ steps.short-sha.outputs.sha }}
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,13 +121,13 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           target: production
           tags: |
             ${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
           builder: ${{ steps.buildx.outputs.name }}
           push: false
-          load: true
+          # load: true
 
       - name: Load Docker Image into kind Cluster
         run: kind load docker-image ${{ env.IMAGE }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -127,8 +127,6 @@ jobs:
             ${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
           builder: ${{ steps.buildx.outputs.name }}
           push: false
-          cache-from: type=gha,scope=${{ github.ref_name }}-${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
-          cache-to: type=gha,scope=${{ github.ref_name }}-${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
           load: true
 
       - name: Load Docker Image into kind Cluster


### PR DESCRIPTION
## Issue

## Description
For helm tests, we used to use the release image of the controller. This can cause issues if the chart changes in a way that tries to launch the Go binary in a way that is not compatible with old Go binary.

This PR adds steps to build and load a local image of the controller using the latest code. The image is not pushed to quay, only used to install the latest image using `ct`.