### PR TITLE
fix: only build/load image if dif detected in chart

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,6 +83,10 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
 
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3
+
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
@@ -111,11 +115,6 @@ jobs:
         uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
         with:
           cluster_name: ct-${{ steps.short-sha.outputs.sha }}
-
-      - name: Set up Docker Buildx
-        if: steps.list-changed.outputs.changed == 'true'
-        id: buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3
 
       - name: Build Docker Image
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,10 +113,12 @@ jobs:
           cluster_name: ct-${{ steps.short-sha.outputs.sha }}
 
       - name: Set up Docker Buildx
+        if: steps.list-changed.outputs.changed == 'true'
         id: buildx
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3
 
       - name: Build Docker Image
+        if: steps.list-changed.outputs.changed == 'true'
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6
         with:
           context: .
@@ -132,6 +134,7 @@ jobs:
           load: true
 
       - name: Load Docker Image into kind Cluster
+        if: steps.list-changed.outputs.changed == 'true'
         run: kind load docker-image ${{ env.IMAGE }}:${{ env.IMAGE_TAG }} --name ct-${{ steps.short-sha.outputs.sha }}
 
       - name: Run chart-testing (install)


### PR DESCRIPTION
Fixes a regression introduced in #31. Image should be built/loaded into a kind cluster only when there is a change in the chart.